### PR TITLE
Add logo component

### DIFF
--- a/packages/frontend/src/components/Logo/Logo.module.css
+++ b/packages/frontend/src/components/Logo/Logo.module.css
@@ -1,0 +1,17 @@
+.logo {
+  font-family: var(--flocker-font-family-logo);
+  color: white;
+  font-size: 5rem;
+}
+
+.colored {
+  color: var(--flocker-color-primary);
+}
+
+.display {
+  font-size: 5rem;
+}
+
+.footer {
+  font-size: 1rem;
+}

--- a/packages/frontend/src/components/Logo/Logo.test.tsx
+++ b/packages/frontend/src/components/Logo/Logo.test.tsx
@@ -1,0 +1,26 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import Logo from './Logo';
+
+test('exists', () => {
+  const { container } = render(<Logo size="footer" />);
+  expect(container).toBeInTheDocument();
+});
+
+test('applies correct color class names', () => {
+  render(<Logo size="footer" colored />);
+  render(<Logo size="footer" />);
+  const logos = screen.getAllByText('Flocker');
+
+  expect(logos[0]).toHaveClass('colored');
+  expect(logos[1]).not.toHaveClass('colored');
+});
+
+test('applies correct sizing class names', () => {
+  render(<Logo size="footer" />);
+  render(<Logo size="display" />);
+  const logos = screen.getAllByText('Flocker');
+
+  expect(logos[0]).toHaveClass('footer');
+  expect(logos[1]).toHaveClass('display');
+});

--- a/packages/frontend/src/components/Logo/Logo.tsx
+++ b/packages/frontend/src/components/Logo/Logo.tsx
@@ -1,0 +1,23 @@
+import styles from './Logo.module.css';
+
+type LogoProps = {
+  colored?: boolean;
+  size: LogoSize;
+};
+
+type LogoSize = 'display' | 'footer';
+
+const computeSizeClass = (type: LogoSize): string => {
+  if (type === 'display') return styles.display;
+  if (type === 'footer') return styles.footer;
+  return '';
+};
+
+const Logo = ({ colored = false, size }: LogoProps) => {
+  const coloredClass = colored ? styles.colored : '';
+  const sizeClass = computeSizeClass(size);
+
+  return <h1 className={`${styles.logo} ${coloredClass} ${sizeClass}`}>Flocker</h1>;
+};
+
+export default Logo;

--- a/packages/frontend/src/components/Logo/README.md
+++ b/packages/frontend/src/components/Logo/README.md
@@ -1,0 +1,16 @@
+# Logo
+
+The Flocker logo. Use it anywhere where needed.
+
+## Props
+
+`size` - _required_
+
+- type: `'display'` | `'footer'`
+- description: Essentially a string enum. When set to `display`, it will be set to the size of the homepage logo. When set to `footer`, it will be small - ideal for footer placement.
+
+`colored` - _optional_
+
+- type: `boolean`
+- default: `false`
+- description: If colored is set, the color of the logo will be the primary color i.e. blue. Otherwise, it will default to white.

--- a/packages/frontend/src/components/Logo/index.ts
+++ b/packages/frontend/src/components/Logo/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Logo';


### PR DESCRIPTION
# Description

Fixes/resolves #31 

Adds the Flocker logo component which can be coloured or not, and in different sizes.
<img width="650" alt="Screen Shot 2022-04-18 at 11 54 43 PM" src="https://user-images.githubusercontent.com/30307624/163804661-7e4e71dc-344f-4155-9b17-0f0c030a5f24.png">


# Checklist

Check only those that apply.

- [x] I have written tests for my change
- [x] I have thoroughly checked my change
- [x] I have written documentation for my change
