### PR TITLE
Add auth context

### DIFF
--- a/packages/frontend/src/contexts/AuthContext.tsx
+++ b/packages/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { createContext, useContext, useState } from 'react';
+import { User } from 'firebase/auth';
+
+type AuthContextType = {
+  user: User | null;
+  setUser: React.Dispatch<React.SetStateAction<User | null>>;
+};
+
+const AuthContext = createContext<AuthContextType>({
+  user: null,
+  setUser: () => null,
+});
+
+export const useAuth = () => useContext(AuthContext);
+
+export const AuthProvider: React.FC<{}> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null);
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        setUser,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import apolloClient from './apollo';
+import { AuthProvider } from './contexts/AuthContext';
 import { ApolloProvider } from '@apollo/client';
 import { StyledEngineProvider } from '@mui/material/styles';
 
@@ -10,7 +11,9 @@ ReactDOM.render(
   <React.StrictMode>
     <ApolloProvider client={apolloClient}>
       <StyledEngineProvider injectFirst>
-        <App />
+        <AuthProvider>
+          <App />
+        </AuthProvider>
       </StyledEngineProvider>
     </ApolloProvider>
   </React.StrictMode>,


### PR DESCRIPTION
# Description

Fixes/resolves #36 

Sets up an auth context provider so that the app has access to the currently logged-in user.

# Checklist

Check only those that apply.

- [ ] I have written tests for my change
- [x] I have thoroughly checked my change
- [ ] I have written documentation for my change
