### PR TITLE
Support authenticated queries

### DIFF
--- a/packages/frontend/src/apollo/index.ts
+++ b/packages/frontend/src/apollo/index.ts
@@ -1,12 +1,30 @@
-import { ApolloClient, InMemoryCache } from '@apollo/client';
+import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
+import { setContext } from '@apollo/client/link/context';
+import { auth } from '../auth/firebase';
 
 const SERVER_URI = process.env.REACT_APP_SERVER_URI;
 if (!SERVER_URI) {
   throw new ReferenceError('REACT_APP_SERVER_URI is not defined.');
 }
 
-const client = new ApolloClient({
+const authLink = setContext(async (_, { headers }) => {
+  const user = auth.currentUser;
+  const token = await user?.getIdToken();
+  return {
+    headers: {
+      ...headers,
+      authorization: token ? `Bearer ${token}` : '',
+    },
+  };
+});
+
+const httpLink = new HttpLink({
   uri: SERVER_URI,
+});
+
+export const link = authLink.concat(httpLink);
+
+const client = new ApolloClient({
   cache: new InMemoryCache(),
 });
 

--- a/packages/frontend/src/contexts/AuthContext.tsx
+++ b/packages/frontend/src/contexts/AuthContext.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { createContext, useContext, useState } from 'react';
 import { User } from 'firebase/auth';
 import { auth } from '../auth/firebase';
+import apolloClient, { link } from '../apollo';
 
 type AuthContextType = {
   user: User | null;
@@ -29,6 +30,7 @@ export const AuthProvider: React.FC<{}> = ({ children }) => {
     const clearListener = auth.onAuthStateChanged((user) => {
       setUser(user);
       setAuthLoaded(true);
+      apolloClient.setLink(link);
     });
 
     return clearListener;


### PR DESCRIPTION
# Description

Fixes/resolves #103 

When a user signs in, the auth token is added to the header of all queries so that authenticated queries can be made.

This thing melted my brain for the entire day

# Checklist

Check only those that apply.

- [ ] I have written tests for my change
- [x] I have thoroughly checked my change
- [ ] I have written documentation for my change
