### PR TITLE
Fix duplicate users being created

### DIFF
--- a/packages/frontend/src/auth/SignIn.tsx
+++ b/packages/frontend/src/auth/SignIn.tsx
@@ -1,51 +1,47 @@
-import { useMutation, useLazyQuery } from '@apollo/client';
+import { useMutation, useLazyQuery, ApolloError } from '@apollo/client';
 import { User } from 'firebase/auth';
-import { useEffect, useCallback } from 'react';
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { GET_CURRENT_USER_NAME, CREATE_NEW_USER } from '../apollo/queries';
 import { useAuth } from '../contexts/AuthContext';
 
 const SignIn: React.FC = () => {
-  const [getCurrentUser, { loading, error, data }] = useLazyQuery(GET_CURRENT_USER_NAME);
   const [createUser] = useMutation(CREATE_NEW_USER);
   const { user } = useAuth();
   const navigate = useNavigate();
 
-  const createFlockerUser = useCallback(
-    async (user: User) => {
-      const name = user.displayName;
-      await createUser({
-        variables: {
-          addUserInput: {
-            name,
-          },
+  const createFlockerUser = async (user: User) => {
+    const name = user.displayName;
+    await createUser({
+      variables: {
+        addUserInput: {
+          name,
         },
-      });
-    },
-    [createUser],
-  );
+      },
+    });
+  };
+
+  const handleError = (err: ApolloError) => {
+    const errorCode = err.graphQLErrors[0].extensions.code;
+    (async () => {
+      if (errorCode === '404' && user) {
+        // User does not exist
+        await createFlockerUser(user);
+        navigate('/dashboard', { replace: true });
+      } else {
+        navigate('/', { replace: true }); // TODO: redirect to an "account could not be created" page
+      }
+    })();
+  };
+
+  const [getCurrentUser] = useLazyQuery(GET_CURRENT_USER_NAME, {
+    onCompleted: () => navigate('/dashboard', { replace: true }),
+    onError: handleError,
+  });
 
   useEffect(() => {
-    getCurrentUser(); // This will trigger `loading` to change
+    getCurrentUser();
   }, [user, getCurrentUser]);
-
-  useEffect(() => {
-    if (loading) return;
-    if (data) navigate('/dashboard', { replace: true }); // User exists, go to dashboard
-
-    if (error) {
-      const errorCode = error.graphQLErrors[0].extensions.code;
-      (async () => {
-        if (errorCode === '404' && user) {
-          // User does not exist
-          await createFlockerUser(user);
-          navigate('/dashboard', { replace: true });
-        } else {
-          navigate('/', { replace: true }); // TODO: redirect to an "account could not be created" page
-        }
-      })();
-    }
-  }, [createFlockerUser, loading, data, error, navigate, user]);
 
   return <></>;
 };


### PR DESCRIPTION
# Description

Fixes/resolves #122 

Because linting required an exhaustive list of dependencies for `useEffect`, the effect to create a new user was run twice (multiple dependencies updating). 

This PR removes the use of `useEffect`, and instead uses the `onCompleted` and `onError` options in `useLazyQuery`.

# Checklist

Check only those that apply.

- [ ] I have written tests for my change
- [ ] I have thoroughly checked my change
- [ ] I have written documentation for my change
