### PR TITLE
Make sign in buttons into separate component

### DIFF
--- a/packages/frontend/src/components/SignInButtons/README.md
+++ b/packages/frontend/src/components/SignInButtons/README.md
@@ -1,0 +1,3 @@
+# SignInButtons
+
+Two buttons (sign in with Google, and continue as guest) separated by a divider.

--- a/packages/frontend/src/components/SignInButtons/SignInButtons.module.css
+++ b/packages/frontend/src/components/SignInButtons/SignInButtons.module.css
@@ -1,0 +1,10 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4em;
+}
+
+.divider {
+  width: 150%;
+}

--- a/packages/frontend/src/components/SignInButtons/SignInButtons.test.tsx
+++ b/packages/frontend/src/components/SignInButtons/SignInButtons.test.tsx
@@ -1,0 +1,23 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import SignInButtons from './SignInButtons';
+import * as firebase from '../../auth/firebase';
+
+beforeAll(() => {});
+
+it('should render', () => {
+  render(<SignInButtons />);
+  expect(screen.getByText('Sign in with Google')).toBeVisible();
+  expect(screen.getByText('or')).toBeVisible();
+  expect(screen.getByText('Continue as Guest')).toBeVisible();
+});
+
+it('should sign in with google', () => {
+  const mock = jest.fn();
+  jest.spyOn(firebase, 'signInWithGoogle').mockImplementation(mock);
+
+  render(<SignInButtons />);
+  const button = screen.getByText('Sign in with Google');
+  fireEvent.click(button);
+  expect(mock).toBeCalledTimes(1);
+});

--- a/packages/frontend/src/components/SignInButtons/SignInButtons.tsx
+++ b/packages/frontend/src/components/SignInButtons/SignInButtons.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import styles from './SignInButtons.module.css';
+import Button from '../Button';
+import Line from '../Line';
+import { signInWithGoogle } from '../../auth/firebase';
+
+const SignInButtons: React.FC = () => (
+  <div className={styles.container}>
+    <Button onClick={signInWithGoogle} color="white" variant="outlined">
+      Sign in with Google
+    </Button>
+    <div className={styles.divider}>
+      <Line text="or" />
+    </div>
+    {/* TODO: Add guest users */}
+    <Button onClick={() => alert('Coming soon')} color="white">
+      Continue as Guest
+    </Button>
+  </div>
+);
+
+export default SignInButtons;

--- a/packages/frontend/src/components/SignInButtons/index.ts
+++ b/packages/frontend/src/components/SignInButtons/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SignInButtons';

--- a/packages/frontend/src/views/HomeView/HomeView.module.css
+++ b/packages/frontend/src/views/HomeView/HomeView.module.css
@@ -23,15 +23,7 @@
 }
 
 .buttons {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.4em;
   z-index: 2;
-}
-
-.divider {
-  width: 150%;
 }
 
 .goose {

--- a/packages/frontend/src/views/HomeView/HomeView.tsx
+++ b/packages/frontend/src/views/HomeView/HomeView.tsx
@@ -1,8 +1,6 @@
 import styles from './HomeView.module.css';
 import Logo from '../../components/Logo';
-import Button from '../../components/Button';
-import Line from '../../components/Line';
-import { signInWithGoogle } from '../../auth/firebase';
+import SignInButtons from '../../components/SignInButtons';
 
 type HomeViewProps = {
   showButtons?: boolean;
@@ -17,16 +15,7 @@ const HomeView: React.FC<HomeViewProps> = ({ showButtons = true }) => {
         <p className={styles.subtitle}>Find a time for you and your group</p>
       </div>
       <div className={styles.buttons} style={{ visibility: buttonVisibility }}>
-        <Button onClick={signInWithGoogle} color="white" variant="outlined">
-          Sign in with Google
-        </Button>
-        <div className={styles.divider}>
-          <Line text="or" />
-        </div>
-        {/* TODO: Add guest users */}
-        <Button onClick={() => alert('Coming soon')} color="white">
-          Continue as Guest
-        </Button>
+        <SignInButtons />
       </div>
       <img
         className={`${styles.goose} ${styles.goose1}`}


### PR DESCRIPTION
# Description

Fixes/resolves #164 

Sign in buttons are moved into a separate component so that they can be reused elsewhere i.e. the "please sign in to join the meeting" view.

# Checklist

Check only those that apply.

- [x] I have written tests for my change
- [x] I have thoroughly checked my change
- [x] I have written documentation for my change
