### PR TITLE
Remove GCal input fields from GQL

### DIFF
--- a/packages/backend/src/graphql/user/inputs/common/userAvailability.input.ts
+++ b/packages/backend/src/graphql/user/inputs/common/userAvailability.input.ts
@@ -13,12 +13,8 @@ export class UserAvailabilityInput implements Partial<UserAvailabilityCombinedDT
   @Field(() => GraphQLString, { nullable: true })
   uri?: string;
 
-  @Field(() => GraphQLString, { nullable: true })
-  refreshToken?: string;
-
-  @Field(() => GraphQLString, { nullable: true })
-  accessToken?: string;
-
-  @Field(() => Date, { nullable: true })
-  accessTokenExpiration?: Date;
+  /**
+   * Google Calendar fields are omitted here, because the Google auth
+   * service communicates directly with the server to add calendars.
+   */
 }

--- a/packages/backend/src/rest/googleCalendar/googleCalendar.controller.ts
+++ b/packages/backend/src/rest/googleCalendar/googleCalendar.controller.ts
@@ -6,10 +6,11 @@ export class GoogleCalendarController {
   constructor(private readonly googleCalendarService: GoogleCalendarService) {}
 
   @Get('/callback')
-  addGoogleCalendar(@Query('code') code: string) {
+  async addGoogleCalendar(@Query('code') code: string) {
     if (!code) {
       throw new BadRequestException('Missing `code` query parameter with Google OAuth2 callback code.');
     }
-    this.googleCalendarService.processCodeCallback(code);
+    await this.googleCalendarService.processCodeCallback(code);
+    return 'Done! Close this window now :)';
   }
 }


### PR DESCRIPTION
# Description

- Removes Google Calendar input fields because the frontend should never manually add GCals (and they shouldn't be able to get a refresh token either).
- Returns a simple message when we finish adding the Google Calendars so it doesn't look like our website broke.