### PR TITLE
Fix data processing of calendar enablement

### DIFF
--- a/packages/frontend/src/views/CalendarView/CalendarView.tsx
+++ b/packages/frontend/src/views/CalendarView/CalendarView.tsx
@@ -126,21 +126,19 @@ const CalendarView: React.FC = () => {
 
     availability.forEach((availability) => {
       const { id, name } = availability as UserAvailabilityPartialDTO;
-      let isEnabled = false;
-      const availabilityForFlock = userAvailabilityForFlock.filter(
-        (userAvailability) => userAvailability.userAvailability === availability,
+      const availabilityForFlock = userAvailabilityForFlock.find(
+        (userAvailability) => (userAvailability.userAvailability as UserAvailabilityPartialDTO).id === id,
       );
-      if (availabilityForFlock) {
-        isEnabled = true;
-      }
+      const enabled = !!availabilityForFlock?.enabled;
 
       calendarList.push({
         name,
         id,
-        enabled: isEnabled,
+        enabled,
         onEnabledChanged: handleUpdateCalendarEnablement,
       });
-      availabilityIds.push(id);
+
+      if (enabled) availabilityIds.push(id);
     });
   }
 


### PR DESCRIPTION
# Description

Fixes/resolves #205

Calendar list enablement changes were not being rendered on the timematcher correctly - fixed now. The setting of calendars to enabled on refresh even though some calendars were disabled was also fixed.

# Checklist

Check only those that apply.

- [ ] I have written tests for my change
- [ ] I have thoroughly checked my change
- [ ] I have written documentation for my change
